### PR TITLE
fix: getByPathMethod use .reach array syntax due to paths containing decimals

### DIFF
--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -57,8 +57,8 @@ endpoints.get = async function (swagger, settings) {
 };
 
 endpoints.getByPathMethod = function(swagger, path, method){
-
-    return Hoek.reach(swagger, 'paths.'+ path + '.' + method.toLowerCase())
+    
+    return Hoek.reach(swagger, ['paths', path, method.toLowerCase()]);
 }
 
 endpoints.copyProperties = function(source, target, propertyNames){


### PR DESCRIPTION
Endpoints can have `.` decimals in such as `/my/api/file.js` which doesn't work with the `hoek.reach` dot syntax. Swapped to array syntax.