### PR TITLE
fix: remove extra callback not required for async JSONDeRef function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -314,7 +314,7 @@ const getSwagger = async function(settings, request) {
   if (settings.swagger && settings.swagger.swagger) {
     // use passed in swagger json object
     let schema = Hoek.clone(settings.swagger);
-    return JSONDeRef.dereference(schema, callback);
+    return JSONDeRef.dereference(schema);
   } else {
     // create swagger json using Hapi-Swagger module, honour settings for module
     var swagger = request.server.plugins["hapi-swagger"];


### PR DESCRIPTION
Looks like `JSONDeRef.dereference(schema)` is used in an async way, so doesn't need the `callback` which is undefined and blocking this code path.